### PR TITLE
Add go-get lines to install the go.mod and other deps.

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -5,6 +5,13 @@ $ git clone https://github.com/go-ap/fedbox
 $ cd fedbox
 ```
 
+## getting the dependencies
+
+```sh
+$ go get .
+$ go get github.com/go-ap/fedbox/internal/cmd
+```
+
 ## compiling
 
 ```sh


### PR DESCRIPTION
`go get .` will fetch the dependencies for the project listed in go.mod. `go get ...` will install an extra required dependency not listed in go.mod.

This is a small documentation issue that I encountered when installing.

I'm not familiar enough (yet) with the go package management to find if this can be automated. Nor do I know for sure if `fedbox/internal/cmd` should rather be a dependency in go.mod too.